### PR TITLE
Refactor/251/refactor get by filter streetcode

### DIFF
--- a/Streetcode/Streetcode.BLL/Mapping/Media/Images/ArtProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Media/Images/ArtProfile.cs
@@ -1,7 +1,10 @@
 using AutoMapper;
 using Streetcode.BLL.DTO.Media.Art;
+using Streetcode.BLL.DTO.Streetcode;
+using Streetcode.BLL.Mapping.Media.Images.Resolvers;
 using Streetcode.DAL.Entities.Media.Images;
-using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Enums;
+using Streetcode.DAL.Enums.EnumExtensions;
 
 namespace Streetcode.BLL.Mapping.Media.Images;
 
@@ -11,5 +14,12 @@ public class ArtProfile : Profile
     {
         CreateMap<Art, ArtDTO>().ReverseMap();
         CreateMap<Art, ArtCreateUpdateDTO>().ReverseMap();
+
+        CreateMap<Art, StreetcodeFilterResultDTO>()
+             .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom<StreetcodeIdResolver>())
+             .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom<StreetcodeIndexResolver>())
+             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Title))
+             .ForMember(dest => dest.BlockName, opt => opt.MapFrom(src => SourceType.ArtGallery.GetDescription()))
+             .ForMember(dest => dest.SourceName, opt => opt.MapFrom(src => SourceName.ArtGallery.GetDescription()));
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Media/Images/Resolvers/StreetcodeIdResolver.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Media/Images/Resolvers/StreetcodeIdResolver.cs
@@ -1,0 +1,13 @@
+﻿using AutoMapper;
+using Streetcode.BLL.DTO.Streetcode;
+using Streetcode.DAL.Entities.Media.Images;
+
+namespace Streetcode.BLL.Mapping.Media.Images.Resolvers;
+
+public class StreetcodeIdResolver : IValueResolver<Art, StreetcodeFilterResultDTO, int>
+{
+    public int Resolve(Art source, StreetcodeFilterResultDTO destination, int destMember, ResolutionContext context)
+    {
+        return source.StreetcodeArts.Find(sa => sa.Streetcode != null) !.StreetcodeId;
+    }
+}

--- a/Streetcode/Streetcode.BLL/Mapping/Media/Images/Resolvers/StreetcodeIndexResolver .cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Media/Images/Resolvers/StreetcodeIndexResolver .cs
@@ -1,0 +1,13 @@
+﻿using AutoMapper;
+using Streetcode.BLL.DTO.Streetcode;
+using Streetcode.DAL.Entities.Media.Images;
+
+namespace Streetcode.BLL.Mapping.Media.Images.Resolvers;
+public class StreetcodeIndexResolver : IValueResolver<Art, StreetcodeFilterResultDTO, int>
+{
+    public int Resolve(Art source, StreetcodeFilterResultDTO destination, int destMember, ResolutionContext context)
+    {
+        var streetcodeArt = source.StreetcodeArts.FirstOrDefault();
+        return streetcodeArt?.Streetcode != null ? streetcodeArt.Streetcode.Index : 0;
+    }
+}

--- a/Streetcode/Streetcode.BLL/Mapping/Media/Images/StreetcodeArtProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Media/Images/StreetcodeArtProfile.cs
@@ -1,6 +1,6 @@
 using AutoMapper;
 using Streetcode.BLL.DTO.Media.Art;
-using Streetcode.DAL.Entities.Media.Images;
+using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.DAL.Entities.Streetcode;
 
 namespace Streetcode.BLL.Mapping.Media.Images;
@@ -10,5 +10,11 @@ public class StreetcodeArtProfile : Profile
     public StreetcodeArtProfile()
     {
         CreateMap<StreetcodeArt, StreetcodeArtDTO>().ReverseMap();
+        CreateMap<StreetcodeArt, StreetcodeFilterResultDTO>()
+            .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.StreetcodeId))
+            .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Streetcode!.Index))
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Art!.Title))
+            .ForMember(dest => dest.BlockName, opt => opt.MapFrom("art-gallery"))
+            .ForMember(dest => dest.SourceName, opt => opt.MapFrom("Арт-галерея"));
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Media/Images/StreetcodeArtProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Media/Images/StreetcodeArtProfile.cs
@@ -1,6 +1,5 @@
 using AutoMapper;
 using Streetcode.BLL.DTO.Media.Art;
-using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.DAL.Entities.Streetcode;
 
 namespace Streetcode.BLL.Mapping.Media.Images;
@@ -10,11 +9,5 @@ public class StreetcodeArtProfile : Profile
     public StreetcodeArtProfile()
     {
         CreateMap<StreetcodeArt, StreetcodeArtDTO>().ReverseMap();
-        CreateMap<StreetcodeArt, StreetcodeFilterResultDTO>()
-            .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.StreetcodeId))
-            .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Streetcode!.Index))
-            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Art!.Title))
-            .ForMember(dest => dest.BlockName, opt => opt.MapFrom("art-gallery"))
-            .ForMember(dest => dest.SourceName, opt => opt.MapFrom("Арт-галерея"));
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/StreetcodeProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/StreetcodeProfile.cs
@@ -43,6 +43,12 @@ public class StreetcodeProfile : Profile
 
         CreateMap<EventStreetcode, CreateStreetcodeDTO>();
         CreateMap<PersonStreetcode, CreateStreetcodeDTO>();
+
+        CreateMap<StreetcodeContent, StreetcodeFilterResultDTO>()
+            .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.StreetcodeTransliterationUrl, opt => opt.MapFrom(src => src.TransliterationUrl))
+            .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Index))
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Title));
     }
 
     private StreetcodeType GetStreetcodeType(StreetcodeContent streetcode)

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/FactProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/FactProfile.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.TextContent.Fact;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 
@@ -10,5 +11,11 @@ public class FactProfile : Profile
     {
         CreateMap<Fact, FactDto>().ReverseMap();
         CreateMap<Fact, FactUpdateCreateDto>().ReverseMap();
+        CreateMap<Fact, StreetcodeFilterResultDTO>()
+            .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.StreetcodeId))
+            .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Streetcode!.Index))
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Title))
+            .ForMember(dest => dest.BlockName, opt => opt.MapFrom("wow-facts"))
+            .ForMember(dest => dest.SourceName, opt => opt.MapFrom("Wow-факти"));
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/FactProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/FactProfile.cs
@@ -2,6 +2,8 @@ using AutoMapper;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.TextContent.Fact;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Streetcode.DAL.Enums;
+using Streetcode.DAL.Enums.EnumExtensions;
 
 namespace Streetcode.BLL.Mapping.Streetcode.TextContent;
 
@@ -15,7 +17,7 @@ public class FactProfile : Profile
             .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.StreetcodeId))
             .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Streetcode!.Index))
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Title))
-            .ForMember(dest => dest.BlockName, opt => opt.MapFrom("wow-facts"))
-            .ForMember(dest => dest.SourceName, opt => opt.MapFrom("Wow-факти"));
+            .ForMember(dest => dest.BlockName, opt => opt.MapFrom(src => SourceType.WowFacts.GetDescription()))
+            .ForMember(dest => dest.SourceName, opt => opt.MapFrom(src => SourceName.WowFacts.GetDescription()));
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TextProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TextProfile.cs
@@ -2,6 +2,8 @@ using AutoMapper;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Streetcode.DAL.Enums;
+using Streetcode.DAL.Enums.EnumExtensions;
 
 namespace Streetcode.BLL.Mapping.Streetcode.TextContent;
 
@@ -16,7 +18,7 @@ public class TextProfile : Profile
             .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.StreetcodeId))
             .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Streetcode!.Index))
             .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Title))
-            .ForMember(dest => dest.BlockName, opt => opt.MapFrom("text"))
-            .ForMember(dest => dest.SourceName, opt => opt.MapFrom("Текст"));
+            .ForMember(dest => dest.BlockName, opt => opt.MapFrom(src => SourceType.Text.GetDescription()))
+            .ForMember(dest => dest.SourceName, opt => opt.MapFrom(src => SourceName.Text.GetDescription()));
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TextProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TextProfile.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 
@@ -10,5 +11,12 @@ public class TextProfile : Profile
     {
         CreateMap<Text, TextDTO>().ReverseMap();
         CreateMap<TextCreateDTO, Text>().ReverseMap();
+
+        CreateMap<Text, StreetcodeFilterResultDTO>()
+            .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.StreetcodeId))
+            .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Streetcode!.Index))
+            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Title))
+            .ForMember(dest => dest.BlockName, opt => opt.MapFrom("text"))
+            .ForMember(dest => dest.SourceName, opt => opt.MapFrom("Текст"));
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Timeline/TimelineItemProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Timeline/TimelineItemProfile.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Timeline;
 using Streetcode.BLL.DTO.Timeline.Create;
 using Streetcode.DAL.Entities.Timeline;
@@ -26,5 +27,11 @@ public class TimelineItemProfile : Profile
                     Title = hct.HistoricalContext!.Title
                 }).ToList()))
             .ReverseMap();
+        CreateMap<TimelineItem, StreetcodeFilterResultDTO>()
+           .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.StreetcodeId))
+           .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Streetcode!.Index))
+           .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Title))
+           .ForMember(dest => dest.BlockName, opt => opt.MapFrom("timeline"))
+           .ForMember(dest => dest.SourceName, opt => opt.MapFrom("Хронологія"));
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Timeline/TimelineItemProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Timeline/TimelineItemProfile.cs
@@ -3,6 +3,8 @@ using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Timeline;
 using Streetcode.BLL.DTO.Timeline.Create;
 using Streetcode.DAL.Entities.Timeline;
+using Streetcode.DAL.Enums;
+using Streetcode.DAL.Enums.EnumExtensions;
 
 namespace Streetcode.BLL.Mapping.Timeline;
 
@@ -27,11 +29,12 @@ public class TimelineItemProfile : Profile
                     Title = hct.HistoricalContext!.Title
                 }).ToList()))
             .ReverseMap();
+
         CreateMap<TimelineItem, StreetcodeFilterResultDTO>()
            .ForMember(dest => dest.StreetcodeId, opt => opt.MapFrom(src => src.StreetcodeId))
            .ForMember(dest => dest.StreetcodeIndex, opt => opt.MapFrom(src => src.Streetcode!.Index))
            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => src.Title))
-           .ForMember(dest => dest.BlockName, opt => opt.MapFrom("timeline"))
-           .ForMember(dest => dest.SourceName, opt => opt.MapFrom("Хронологія"));
+           .ForMember(dest => dest.BlockName, opt => opt.MapFrom(src => SourceType.Timeline.GetDescription()))
+           .ForMember(dest => dest.SourceName, opt => opt.MapFrom(src => SourceName.Timeline.GetDescription()));
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetByFilter/GetStreetcodeByFilterQuery.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetByFilter/GetStreetcodeByFilterQuery.cs
@@ -1,9 +1,10 @@
 using FluentResults;
 using MediatR;
+using Streetcode.BLL.Behavior;
 using Streetcode.BLL.DTO.AdditionalContent.Filter;
 using Streetcode.BLL.DTO.Streetcode;
 
 namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.GetByFilter
 {
-    public record class GetStreetcodeByFilterQuery(StreetcodeFilterRequestDTO Filter) : IRequest<Result<List<StreetcodeFilterResultDTO>>>;
+    public record class GetStreetcodeByFilterQuery(StreetcodeFilterRequestDTO Filter) : IValidatableRequest<Result<List<StreetcodeFilterResultDTO>>>;
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetByFilter/StreetcodeFilterRequestDTOValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/GetByFilter/StreetcodeFilterRequestDTOValidator.cs
@@ -1,0 +1,10 @@
+﻿using FluentValidation;
+namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.GetByFilter;
+
+public class StreetcodeFilterRequestDtoValidator : AbstractValidator<GetStreetcodeByFilterQuery>
+{
+    public StreetcodeFilterRequestDtoValidator()
+    {
+        RuleFor(x => x.Filter.SearchQuery).NotNull().NotEmpty();
+    }
+}

--- a/Streetcode/Streetcode.BLL/Resources/ErrorMessages.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/ErrorMessages.Designer.cs
@@ -106,6 +106,15 @@ namespace Streetcode.BLL.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search query cannot be null or empty.
+        /// </summary>
+        public static string EmptyQuery {
+            get {
+                return ResourceManager.GetString("EmptyQuery", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot find any {0}.
         /// </summary>
         public static string EntityNotFound {
@@ -356,57 +365,5 @@ namespace Streetcode.BLL.Resources {
                 return ResourceManager.GetString("UserNotFound", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot find streetcode by transliteration url: {1}.
-        /// </summary>
-        public static string ExpiredToken
-        {
-            get
-            {
-                return ResourceManager.GetString("TokenExpired", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot find streetcode by transliteration url: {1}.
-        /// </summary>
-        public static string ClaimsNotExist
-        {
-            get
-            {
-                return ResourceManager.GetString("ClaimsNotExist", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot find streetcode by transliteration url: {1}.
-        /// </summary>
-        public static string AccessTokenNotFound
-        {
-            get
-            {
-                return ResourceManager.GetString("AccessTokenNotFound", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot find streetcode by transliteration url: {1}.
-        /// </summary>
-        public static string UserUpdateFailed
-        {
-            get
-            {
-                return ResourceManager.GetString("UserUpdateFailed", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot find streetcode by transliteration url: {1}.
-        /// </summary>
-        public static string FailedToSetTokenInBlackList
-        {
-            get
-            {
-                return ResourceManager.GetString("Failed to set token in black list", resourceCulture);
-            }
-        }
-
     }
 }

--- a/Streetcode/Streetcode.BLL/Resources/ErrorMessages.resx
+++ b/Streetcode/Streetcode.BLL/Resources/ErrorMessages.resx
@@ -216,4 +216,7 @@
   <data name="RolesNotFound" xml:space="preserve">
     <value>Roles not found</value>
   </data>
+  <data name="EmptyQuery" xml:space="preserve">
+    <value>Search query cannot be null or empty</value>
+  </data>
 </root>

--- a/Streetcode/Streetcode.BLL/Specification/Media/Art/GetByStreetcode/ArtsFilteredByQuerySpec.cs
+++ b/Streetcode/Streetcode.BLL/Specification/Media/Art/GetByStreetcode/ArtsFilteredByQuerySpec.cs
@@ -3,13 +3,13 @@ using Streetcode.DAL.Entities.Media.Images;
 
 namespace Streetcode.BLL.Specification.Media.ArtSpec.GetByStreetcode;
 
-public class ArtByPublStreetcodesIncludeImageSpec : Specification<Art>
+public class ArtsFilteredByQuerySpec : Specification<Art>
 {
-    public ArtByPublStreetcodesIncludeImageSpec()
+    public ArtsFilteredByQuerySpec(string query)
     {
         Query.Include(x => x.StreetcodeArts)
              .Where(x => x.StreetcodeArts.Any(art => art.Streetcode != null
-            && art.Streetcode.Status == DAL.Enums.StreetcodeStatus.Published))
-            .Include(x => x.Image);
+             && art.Streetcode.Status == DAL.Enums.StreetcodeStatus.Published)
+             && (!string.IsNullOrEmpty(x.Description) && x.Description.Contains(query)));
     }
 }

--- a/Streetcode/Streetcode.BLL/Specification/Streetcode/Streetcode/GetByFilter/StreetcodesFilteredByQuerySpec.cs
+++ b/Streetcode/Streetcode.BLL/Specification/Streetcode/Streetcode/GetByFilter/StreetcodesFilteredByQuerySpec.cs
@@ -1,0 +1,16 @@
+﻿using Ardalis.Specification;
+using Streetcode.DAL.Entities.Streetcode;
+
+namespace Streetcode.BLL.Specification.Streetcode.Streetcode.GetByFilter;
+
+public class StreetcodesFilteredByQuerySpec : Specification<StreetcodeContent>
+{
+     public StreetcodesFilteredByQuerySpec(string searchQuery)
+     {
+        Query.Where(x =>
+        (x.Status == DAL.Enums.StreetcodeStatus.Published) &&
+        ((!string.IsNullOrEmpty(x.Title) && x.Title.Contains(searchQuery)) ||
+        (!string.IsNullOrEmpty(x.Alias) && x.Alias.Contains(searchQuery)) ||
+         (!string.IsNullOrEmpty(x.Teaser) && x.Teaser.Contains(searchQuery))));
+     }
+}

--- a/Streetcode/Streetcode.BLL/Specification/Streetcode/Text/GetAll/TextFilteredByQuerySpec.cs
+++ b/Streetcode/Streetcode.BLL/Specification/Streetcode/Text/GetAll/TextFilteredByQuerySpec.cs
@@ -1,0 +1,19 @@
+﻿using Ardalis.Specification;
+using Streetcode.DAL.Entities.Streetcode.TextContent;
+
+namespace Streetcode.BLL.Specification.Streetcode.TextSec.GetAll;
+
+public class TextFilteredByQuerySpec : Specification<Text>
+{
+    public TextFilteredByQuerySpec(string query)
+    {
+        if(!string.IsNullOrEmpty(query))
+        {
+            Query.Include(x => x.Streetcode)
+             .Where(x => x.Streetcode != null &&
+                x.Streetcode.Status == DAL.Enums.StreetcodeStatus.Published &&
+                ((!string.IsNullOrEmpty(x.Title) && x.Title.Contains(query)) ||
+                 (!string.IsNullOrEmpty(x.TextContent) && x.TextContent.Contains(query))));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/Specification/Streetcode/TextContent/Fact/GetAll/FactsFilteredByQuerySpec.cs
+++ b/Streetcode/Streetcode.BLL/Specification/Streetcode/TextContent/Fact/GetAll/FactsFilteredByQuerySpec.cs
@@ -1,0 +1,16 @@
+﻿using Ardalis.Specification;
+using Streetcode.DAL.Entities.Streetcode.TextContent;
+
+namespace Streetcode.BLL.Specification.Streetcode.TextContent.FactSpec.GetAll;
+
+public class FactsFilteredByQuerySpec : Specification<Fact>
+{
+    public FactsFilteredByQuerySpec(string query)
+    {
+        Query.Include(fact => fact.Streetcode)
+          .Where(x => x.Streetcode != null
+          && x.Streetcode.Status == DAL.Enums.StreetcodeStatus.Published &&
+                ((!string.IsNullOrEmpty(x.Title) && x.Title.Contains(query)) ||
+                 (!string.IsNullOrEmpty(x.FactContent) && x.FactContent.Contains(query))));
+    }
+}

--- a/Streetcode/Streetcode.BLL/Specification/TimeLine/TimeLineFilteredByQuerySpec.cs
+++ b/Streetcode/Streetcode.BLL/Specification/TimeLine/TimeLineFilteredByQuerySpec.cs
@@ -1,0 +1,15 @@
+﻿using Ardalis.Specification;
+using Org.BouncyCastle.Asn1.X509;
+using Streetcode.DAL.Entities.Timeline;
+
+namespace Streetcode.BLL.Specification.TimeLine;
+
+public class TimeLineFilteredByQuerySpec : Specification<TimelineItem>
+{
+    public TimeLineFilteredByQuerySpec(string query)
+    {
+        Query.Include(tm => tm.Streetcode)
+            .Where(tm => tm.Streetcode != null &&
+            tm.Streetcode.Status == DAL.Enums.StreetcodeStatus.Published);
+    }
+}

--- a/Streetcode/Streetcode.BLL/Specification/TimeLine/TimeLinesIncludePublishStreetcodeSpec.cs
+++ b/Streetcode/Streetcode.BLL/Specification/TimeLine/TimeLinesIncludePublishStreetcodeSpec.cs
@@ -1,14 +1,17 @@
 ﻿using Ardalis.Specification;
 using Streetcode.DAL.Entities.Timeline;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 
 namespace Streetcode.BLL.Specification.TimeLine;
 
 public class TimeLinesIncludePublishStreetcodeSpec : Specification<TimelineItem>
 {
-    public TimeLinesIncludePublishStreetcodeSpec()
+    public TimeLinesIncludePublishStreetcodeSpec(string query)
     {
         Query.Include(tm => tm.Streetcode)
             .Where(tm => tm.Streetcode != null &&
-            tm.Streetcode.Status == DAL.Enums.StreetcodeStatus.Published);
+            tm.Streetcode.Status == DAL.Enums.StreetcodeStatus.Published &&
+                ((!string.IsNullOrEmpty(tm.Title) && tm.Title.Contains(query)) ||
+                 (!string.IsNullOrEmpty(tm.Description) && tm.Description.Contains(query))));
     }
 }

--- a/Streetcode/Streetcode.DAL/Enums/EnumExtensions/EnumExtensions.cs
+++ b/Streetcode/Streetcode.DAL/Enums/EnumExtensions/EnumExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+
+namespace Streetcode.DAL.Enums.EnumExtensions;
+
+public static class EnumExtensions
+{
+    public static string GetDescription(this Enum value)
+    {
+        var field = value.GetType().GetField(value.ToString());
+        var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+        return attribute == null ? value.ToString() : attribute.Description;
+    }
+}

--- a/Streetcode/Streetcode.DAL/Enums/SourceName.cs
+++ b/Streetcode/Streetcode.DAL/Enums/SourceName.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+
+namespace Streetcode.DAL.Enums;
+
+public enum SourceName
+{
+    [Description("Wow-факти")]
+    WowFacts,
+    [Description("Текст")]
+    Text,
+    [Description("Арт-галерея")]
+    ArtGallery,
+    [Description("Хронологія")]
+    Timeline
+}

--- a/Streetcode/Streetcode.DAL/Enums/SourceType.cs
+++ b/Streetcode/Streetcode.DAL/Enums/SourceType.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+
+namespace Streetcode.DAL.Enums;
+
+public enum SourceType
+{
+    [Description("wow-facts")]
+    WowFacts,
+    [Description("text")]
+    Text,
+    [Description("art-gallery")]
+    ArtGallery,
+    [Description("timeline")]
+    Timeline
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/Streetcode/GetStreetcodeByFilterHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/Streetcode/GetStreetcodeByFilterHandlerTests.cs
@@ -1,0 +1,157 @@
+﻿using AutoMapper;
+using Moq;
+using Streetcode.BLL.DTO.Streetcode;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Streetcode.Streetcode.GetByFilter;
+using Streetcode.BLL.Resources;
+using Streetcode.BLL.Specification.Media.ArtSpec.GetByStreetcode;
+using Streetcode.BLL.Specification.Streetcode.Streetcode.GetByFilter;
+using Streetcode.BLL.Specification.Streetcode.TextContent.FactSpec.GetAll;
+using Streetcode.BLL.Specification.Streetcode.TextSec.GetAll;
+using Streetcode.BLL.Specification.TimeLine;
+using Streetcode.DAL.Entities.Media.Images;
+using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+using Streetcode.BLL.DTO.AdditionalContent.Filter;
+using Streetcode.DAL.Entities.Timeline;
+
+namespace Streetcode.XUnitTest.MediatRTests.StreetcodeTests.StreetcodeTest;
+
+public class GetStreetcodeByFilterHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<ILoggerService> _loggerMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly GetStreetcodeByFilterHandler _handler;
+
+    public GetStreetcodeByFilterHandlerTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _loggerMock = new Mock<ILoggerService>();
+        _mapperMock = new Mock<IMapper>();
+        _handler = new GetStreetcodeByFilterHandler(_repositoryWrapperMock.Object, _loggerMock.Object, _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_EmptySearchQuery_ReturnsFailResult()
+    {
+        // Arrange
+        var request = CreateQuery(string.Empty);
+        var cancellationToken = CancellationToken.None;
+        SetupMapper();
+
+        // Act
+        var result = await _handler.Handle(request, cancellationToken);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ValidSearchQuery_ReturnsSuccessResult()
+    {
+        // Arrange
+        var request = CreateQuery("valid-query");
+        var cancellationToken = CancellationToken.None;
+
+        SetupRepositories(
+            streetcodeResults: new List<StreetcodeContent> { new StreetcodeContent() },
+            textResults: new List<DAL.Entities.Streetcode.TextContent.Text> { new DAL.Entities.Streetcode.TextContent.Text() },
+            factResults: new List<Fact> { new Fact() },
+            timelineResults: new List<TimelineItem> { new TimelineItem() });
+
+        // Act
+        var result = await _handler.Handle(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(5, result.Value.Count); 
+    }
+
+    [Fact]
+    public async Task Handle_ArtResultsWithNullStreetcode_ExcludesNullStreetcode()
+    {
+        // Arrange
+        var request = CreateQuery("valid-query");
+        var cancellationToken = CancellationToken.None;
+
+        var artResults = CreateArtResultsWithNullStreetcode();
+
+        SetupRepositories(artResults: artResults);
+        SetupMapper();
+
+        // Act
+        var result = await _handler.Handle(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(1, result.Value?.Count);
+    }
+
+    private void SetupRepositories(
+      List<StreetcodeContent>? streetcodeResults = null,
+      List<DAL.Entities.Streetcode.TextContent.Text>? textResults = null,
+      List<Fact>? factResults = null,
+      List<TimelineItem>? timelineResults = null,
+      List<Art>? artResults = null)
+    {
+        streetcodeResults ??= new List<StreetcodeContent>();
+        textResults ??= new List<DAL.Entities.Streetcode.TextContent.Text>();
+        factResults ??= new List<Fact>();
+        timelineResults ??= new List<TimelineItem>();
+        artResults ??= new List<Art>()
+        {
+            new ()
+            {
+                StreetcodeArts = new List<StreetcodeArt>
+                    {
+                        new StreetcodeArt { Streetcode = new StreetcodeContent() },
+                    }
+            }
+        };
+
+        _repositoryWrapperMock.Setup(repo => repo.StreetcodeRepository.GetAllWithSpecAsync(It.IsAny<StreetcodesFilteredByQuerySpec>()))
+            .ReturnsAsync(streetcodeResults);
+
+        _repositoryWrapperMock.Setup(repo => repo.TextRepository.GetAllWithSpecAsync(It.IsAny<TextFilteredByQuerySpec>()))
+            .ReturnsAsync(textResults);
+
+        _repositoryWrapperMock.Setup(repo => repo.FactRepository.GetAllWithSpecAsync(It.IsAny<FactsFilteredByQuerySpec>()))
+            .ReturnsAsync(factResults);
+
+        _repositoryWrapperMock.Setup(repo => repo.TimelineRepository.GetAllWithSpecAsync(It.IsAny<TimeLinesIncludePublishStreetcodeSpec>()))
+            .ReturnsAsync(timelineResults);
+
+        _repositoryWrapperMock.Setup(repo => repo.ArtRepository.GetAllWithSpecAsync(It.IsAny<ArtsFilteredByQuerySpec>()))
+            .ReturnsAsync(artResults);
+
+        SetupMapper();
+    }
+
+    private void SetupMapper()
+    {
+        _mapperMock.Setup(mapper => mapper.Map<StreetcodeFilterResultDTO>(It.IsAny<object>()))
+            .Returns(new StreetcodeFilterResultDTO());
+    }
+
+    private List<Art> CreateArtResultsWithNullStreetcode()
+    {
+        return new List<Art>
+            {
+                new Art
+                {
+                    StreetcodeArts = new List<StreetcodeArt>
+                    {
+                        new StreetcodeArt { Streetcode = null },
+                        new StreetcodeArt { Streetcode = new StreetcodeContent() }
+                    }
+                }
+            };
+    }
+
+    private GetStreetcodeByFilterQuery CreateQuery(string searchQuery)
+    {
+        var filter = new StreetcodeFilterRequestDTO { SearchQuery = searchQuery };
+        return new GetStreetcodeByFilterQuery(filter);
+    }
+}


### PR DESCRIPTION
* [Ticket 251](https://github.com/project-studying-dotnet/Streetcode-Server-June/issues/251)


- Refactored the `GetStreetcodeByFilterHandler` to improve readability and maintainability.
 - Extracted logic for adding results from different repositories into separate methods (`AddResultsAsync`,  `AddArtResultsAsync`).
  - Used AutoMapper to map entities to DTOs.